### PR TITLE
Reduce deprecation warnings in tests

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -3,3 +3,10 @@ testpaths = tests/
 norecursedirs = .* *.egg *.egg-info env* devenv* docs
 addopts = -m "not abci"
 looponfailroots = planetmint tests
+asyncio_mode = strict
+markers = 
+    userfixtures
+    language
+    tendermint
+    usefixture
+    execute

--- a/setup.py
+++ b/setup.py
@@ -74,7 +74,7 @@ tests_require = [
 
 install_requires = [
     'chardet==3.0.4',
-    'aiohttp==3.8.1',
+    'aiohttp==3.7.4',
     'bigchaindb-abci==1.0.7',
     'planetmint-cryptoconditions>=0.9.0',
     'flask-cors==3.0.10',

--- a/setup.py
+++ b/setup.py
@@ -74,7 +74,7 @@ tests_require = [
 
 install_requires = [
     'chardet==3.0.4',
-    'aiohttp==3.7.4',
+    'aiohttp==3.8.1',
     'bigchaindb-abci==1.0.7',
     'planetmint-cryptoconditions>=0.9.0',
     'flask-cors==3.0.10',

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,6 +9,7 @@ Tasks:
 1. setup test database before starting the tests
 2. delete test database after running the tests
 """
+import asyncio
 import json
 import os
 import copy
@@ -430,7 +431,7 @@ def abci_http(_setup_database, _configure_planetmint, abci_server,
     return False
 
 
-@pytest.yield_fixture(scope='session')
+@pytest.fixture(scope='session')
 def event_loop():
     import asyncio
 


### PR DESCRIPTION
**Problem: Deprecation warnings in test**

## Solution

Changed fixtures and config of tests to support auto mode to allow strict asyncio mode in future