### PR TITLE
Added support for Tendermint v0.34.15.

### DIFF
--- a/Dockerfile-all-in-one
+++ b/Dockerfile-all-in-one
@@ -1,7 +1,7 @@
 FROM alpine:3.9
 LABEL maintainer "contact@ipdb.global"
 
-ARG TM_VERSION=v0.34.11
+ARG TM_VERSION=v0.34.15
 RUN mkdir -p /usr/src/app
 ENV HOME /root
 COPY . /usr/src/app/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -51,7 +51,7 @@ services:
     command: '.ci/entrypoint.sh'
     restart: always
   tendermint:
-    image: tendermint/tendermint:v0.34.11
+    image: tendermint/tendermint:v0.34.15
     # volumes:
     #   - ./tmdata:/tendermint
     entrypoint: ''

--- a/docs/root/source/contributing/dev-setup-coding-and-contribution-process/run-node-as-processes.md
+++ b/docs/root/source/contributing/dev-setup-coding-and-contribution-process/run-node-as-processes.md
@@ -30,9 +30,9 @@ The version of Planetmint Server described in these docs only works well with Te
 
 ```bash
 $ sudo apt install -y unzip
-$ wget https://github.com/tendermint/tendermint/releases/download/v0.34.11/tendermint_v0.34.11_linux_amd64.zip
-$ unzip tendermint_v0.34.11_linux_amd64.zip
-$ rm tendermint_v0.34.11_linux_amd64.zip
+$ wget https://github.com/tendermint/tendermint/releases/download/v0.34.15/tendermint_v0.34.15_linux_amd64.zip
+$ unzip tendermint_v0.34.15_linux_amd64.zip
+$ rm tendermint_v0.34.15_linux_amd64.zip
 $ sudo mv tendermint /usr/local/bin
 ```
 

--- a/docs/root/source/installation/network-setup/k8s-deployment-template/workflow.rst
+++ b/docs/root/source/installation/network-setup/k8s-deployment-template/workflow.rst
@@ -60,7 +60,7 @@ you can do this:
 .. code::
 
    $ mkdir $(pwd)/tmdata
-   $ docker run --rm -v $(pwd)/tmdata:/tendermint/config tendermint/tendermint:v0.34.11 init
+   $ docker run --rm -v $(pwd)/tmdata:/tendermint/config tendermint/tendermint:v0.34.15 init
    $ cat $(pwd)/tmdata/genesis.json
 
 You should see something that looks like:

--- a/k8s/planetmint/tendermint_container/Dockerfile
+++ b/k8s/planetmint/tendermint_container/Dockerfile
@@ -1,4 +1,4 @@
-FROM tendermint/tendermint:v0.34.11
+FROM tendermint/tendermint:v0.34.15
 LABEL maintainer "contact@ipdb.global"
 WORKDIR /
 USER root

--- a/pkg/scripts/stack.sh
+++ b/pkg/scripts/stack.sh
@@ -17,7 +17,7 @@ stack_size=${STACK_SIZE:=4}
 stack_type=${STACK_TYPE:="docker"}
 stack_type_provider=${STACK_TYPE_PROVIDER:=""}
 # NOTE versions prior v0.28.0 have different priv_validator format!
-tm_version=${TM_VERSION:="v0.34.11"}
+tm_version=${TM_VERSION:="v0.34.15"}
 mongo_version=${MONGO_VERSION:="3.6"}
 stack_vm_memory=${STACK_VM_MEMORY:=2048}
 stack_vm_cpus=${STACK_VM_CPUS:=2}

--- a/planetmint/__init__.py
+++ b/planetmint/__init__.py
@@ -71,7 +71,7 @@ config = {
     'tendermint': {
         'host': 'localhost',
         'port': 26657,
-        'version': 'v0.34.11',  # look for __tm_supported_versions__
+        'version': 'v0.34.15',  # look for __tm_supported_versions__
     },
     # FIXME: hardcoding to localmongodb for now
     'database': _database_map['localmongodb'],

--- a/planetmint/version.py
+++ b/planetmint/version.py
@@ -7,4 +7,4 @@ __version__ = '0.9.0'
 __short_version__ = '0.9'
 
 # Supported Tendermint versions
-__tm_supported_versions__ = ["0.34.11"]
+__tm_supported_versions__ = ["0.34.15"]

--- a/tests/test_config_utils.py
+++ b/tests/test_config_utils.py
@@ -221,7 +221,7 @@ def test_autoconfigure_read_both_from_file_and_env(monkeypatch, request):
         'tendermint': {
             'host': 'localhost',
             'port': 26657,
-            'version': 'v0.34.11'
+            'version': 'v0.34.15'
         },
         'log': {
             'file': LOG_FILE,


### PR DESCRIPTION

**Problem: Planetmint does not support Tendermint v0.34.15.**

## Solution

This PR upgrades its support to the latest Tendermint v0.34.15.

## Issues Resolved

Resolves #32 
