### PR TITLE
Fixes some test cases in tendermint/test_lib.py

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -552,7 +552,7 @@ def tarantool_client(db_context):  # TODO Here add TarantoolConnectionClass
 #
 
 @pytest.fixture
-def utxo_collection(tarantool_client):
+def utxo_collection(tarantool_client, _setup_database):
     return tarantool_client.get_space("utxos")
 
 
@@ -568,10 +568,12 @@ def dummy_unspent_outputs():
 @pytest.fixture
 def utxoset(dummy_unspent_outputs, utxo_collection):
     from json import dumps
+    num_rows_before_operation = utxo_collection.select().rowcount
     for utxo in dummy_unspent_outputs:
         res = utxo_collection.insert((utxo["transaction_id"], utxo["output_index"], dumps(utxo)))
         assert res
-    assert len(utxo_collection.select()) == 3
+    num_rows_after_operation = utxo_collection.select().rowcount
+    assert num_rows_after_operation == num_rows_before_operation + 3
     return dummy_unspent_outputs, utxo_collection
 
 

--- a/tests/tendermint/test_lib.py
+++ b/tests/tendermint/test_lib.py
@@ -288,9 +288,11 @@ def test_store_bulk_transaction(mocker, b, signed_create_tx,
 @pytest.mark.bdb
 def test_delete_zero_unspent_outputs(b, utxoset):
     unspent_outputs, utxo_collection = utxoset
+    num_rows_before_operation = utxo_collection.select().rowcount
     delete_res = b.delete_unspent_outputs()
+    num_rows_after_operation = utxo_collection.select().rowcount
     # assert delete_res is None
-    assert utxo_collection.select().rowcount == 3
+    assert num_rows_before_operation == num_rows_after_operation
     # assert utxo_collection.count_documents(
     #     {'$or': [
     #         {'transaction_id': 'a', 'output_index': 0},
@@ -350,9 +352,11 @@ def test_delete_many_unspent_outputs(b, utxoset):
 
 @pytest.mark.bdb
 def test_store_zero_unspent_output(b, utxo_collection):
+    num_rows_before_operation = utxo_collection.select().rowcount
     res = b.store_unspent_outputs()
+    num_rows_after_operation = utxo_collection.select().rowcount
     assert res is None
-    assert utxo_collection.select().rowcount == 0
+    assert num_rows_before_operation == num_rows_after_operation
 
 
 @pytest.mark.bdb


### PR DESCRIPTION
Make sure the title of this pull request has the form:

**Problem: In some test cases in tendermint/test_lib.py, the number of tuples in the database before and after the operation were coming as different**

## Solution

I have modified the test case a little bit to solve this issue. The core issue remains that the database is not being re-initialized properly after each test case for these particular test cases.

`
@pytest.fixture
def utxo_collection(tarantool_client, _setup_database):
    return tarantool_client.get_space("utxos")
`
I have tried using _setup_database fixture in the utxo_collection fixture but it didn't show any effect. I'll do further investigations but for now this PR resolves 1 FAILED and 1 ERROR in test cases.

Below screenshots show the places where I have made the changes:

<img width="493" alt="image" src="https://user-images.githubusercontent.com/20491970/172805878-c857a5ec-15d2-4ff9-8a9c-7c79f5e2114d.png">

<img width="440" alt="image" src="https://user-images.githubusercontent.com/20491970/172806041-3bf4136b-113a-47bf-9c2d-aa7eed11e14c.png">

<img width="698" alt="image" src="https://user-images.githubusercontent.com/20491970/172806163-42abfecf-b9bf-49fe-99f2-0a46092ed9a6.png">

