### PR TITLE
Example zencode scripts fail with the last version of zenroom

### DIFF
--- a/acceptance/python/src/conftest.py
+++ b/acceptance/python/src/conftest.py
@@ -20,7 +20,7 @@ SK_TO_PK = \
     Rule output encoding base58
     Scenario 'ecdh': Create the keypair
     Given that I am known as '{}'
-    Given I have the 'keys'
+    Given I have the 'keyring'
     When I create the ecdh public key
     When I create the testnet address
     Then print my 'ecdh public key'
@@ -58,7 +58,7 @@ ZENROOM_DATA = {
 CONDITION_SCRIPT = """Rule input encoding base58
     Rule output encoding base58
     Scenario 'ecdh': create the signature of an object
-    Given I have the 'keys'
+    Given I have the 'keyring'
     Given that I have a 'string dictionary' named 'houses' inside 'asset'
     When I create the signature of 'houses'
     When I rename the 'signature' to 'data.signature'

--- a/acceptance/python/src/test_zenroom.py
+++ b/acceptance/python/src/test_zenroom.py
@@ -16,13 +16,13 @@ from json.decoder import JSONDecodeError
 
 def test_zenroom(gen_key_zencode, secret_key_to_private_key_zencode, fulfill_script_zencode, 
 condition_script_zencode, zenroom_data, zenroom_house_assets):
-    alice = json.loads(ZenroomSha256.run_zenroom(gen_key_zencode).output)['keys']
-    bob = json.loads(ZenroomSha256.run_zenroom(gen_key_zencode).output)['keys']
+    alice = json.loads(ZenroomSha256.run_zenroom(gen_key_zencode).output)['keyring']
+    bob = json.loads(ZenroomSha256.run_zenroom(gen_key_zencode).output)['keyring']
 
     zen_public_keys = json.loads(ZenroomSha256.run_zenroom(secret_key_to_private_key_zencode.format('Alice'),
-                                                keys={'keys': alice}).output)
+                                                keys={'keyring': alice}).output)
     zen_public_keys.update(json.loads(ZenroomSha256.run_zenroom(secret_key_to_private_key_zencode.format('Bob'),
-                                                keys={'keys': bob}).output))
+                                                keys={'keyring': bob}).output))
 
     # CRYPTO-CONDITIONS: instantiate an Ed25519 crypto-condition for buyer
     zenSha = ZenroomSha256(script=fulfill_script_zencode, keys=zen_public_keys, data=zenroom_data)


### PR DESCRIPTION
Replace `keys` with `keyring`.


