### PR TITLE
Planetmint tarantool

### DIFF
--- a/planetmint/backend/tarantool/schema.py
+++ b/planetmint/backend/tarantool/schema.py
@@ -32,8 +32,8 @@ SPACE_COMMANDS = {
 INDEX_COMMANDS = {
     "abci_chains":
         {
-            "id_search": "abci_chains:create_index('id_search' ,{type='hash', parts={'chain_id'}})",
-            "height_search": "abci_chains:create_index('height_search' ,{type='tree',unique=false, parts={'height'}})"
+            "id_search": "abci_chains:create_index('id_search' ,{type='hash', parts={'id'}})",
+            "height_search": "abci_chains:create_index('height_search' ,{type='tree', unique=false, parts={'height'}})"
         },
     "assets":
         {
@@ -105,7 +105,7 @@ INDEX_COMMANDS = {
 
 SCHEMA_COMMANDS = {
     "abci_chains":
-        "abci_chains:format({{name='height' , type='integer'},{name='is_synched' , type='boolean'},{name='chain_id',type='string'}})",
+        "abci_chains:format({{name='height' , type='integer'},{name='is_synched' , type='boolean'},{name='chain_id',type='string'}, {name='id', type='string'}})",
     "assets":
         "assets:format({{name='data' , type='any'}, {name='tx_id', type='string'}, {name='asset_id', type='string'}})",
     "blocks":

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -39,7 +39,7 @@ def flush_tarantool_db(connection, dbname):
         for _id in _all_data:
             if "assets" == s:
                 connection.run(connection.space(s).delete(_id[1]), only_data=False)
-            elif s in ["blocks", "abci_chains"]:
+            elif s == "blocks":
                 connection.run(connection.space(s).delete(_id[2]), only_data=False)
             elif s == "inputs":
                 connection.run(connection.space(s).delete(_id[-2]), only_data=False)
@@ -47,6 +47,8 @@ def flush_tarantool_db(connection, dbname):
                 connection.run(connection.space(s).delete(_id[-4]), only_data=False)
             elif s == "utxos":
                 connection.run(connection.space(s).delete([_id[0], _id[1]]), only_data=False)
+            elif s == "abci_chains":
+                connection.run(connection.space(s).delete(_id[-1]), only_data=False)
             else:
                 connection.run(connection.space(s).delete(_id[0]), only_data=False)
 


### PR DESCRIPTION
## Problem

Upsert function is not working properly because you can't change primary key(index) in tarantool space.
But tests needs that.

## Solution
Fixed by adding new field 'id' to abci_chains space and converting {'height': int} to string and generating a hash from that string.

## Comments
-- Remember upsert() method can't update keys that are used as unique in indexes --
**Why only height was converted to string ?**
1) **if you will use height as primary key or any other field except new 'id' field.**
  - Problem is that if you store this tuple (1, False, 'Chain-ID') and after some time comes a request to update it,
   you will not be able to update it because you will also try to update unique field, in any possible case.
2) **if you use only new id field as primary key**
   - You can update any necessary field, and upsert() method will work fine.

If 'height' field is updated with upsert() method, it will fail, because primary key is equal to height.
I couldn't find if 'height' field is being updated using upsert() functions. (even in mongodb implementation)
If it doesn't happen, then we will not encounter any problem.
