### PR TITLE
Resolved issues related to key error

### DIFF
--- a/planetmint/backend/tarantool/query.py
+++ b/planetmint/backend/tarantool/query.py
@@ -171,7 +171,7 @@ def get_assets(connection, assets_ids: list) -> list:
         asset = get_asset(connection, _id)
         _returned_data.append(asset)
 
-    return sorted(_returned_data, key=lambda k: k["id"], reverse=False)
+    return sorted(_returned_data, key=lambda k: ("id" not in k, k.get("id", None)), reverse=False)
 
 
 @register_query(TarantoolDBConnection)

--- a/planetmint/backend/tarantool/query.py
+++ b/planetmint/backend/tarantool/query.py
@@ -168,10 +168,12 @@ def get_asset(connection, asset_id: str):
 def get_assets(connection, assets_ids: list) -> list:
     _returned_data = []
     for _id in list(set(assets_ids)):
-        asset = get_asset(connection, _id)
-        _returned_data.append(asset)
-
-    return sorted(_returned_data, key=lambda k: ("id" not in k, k.get("id", None)), reverse=False)
+        res = connection.run(
+            connection.space("assets").select(_id, index="txid_search")
+        )
+        _returned_data.append(res[0])
+    sorted_assets = sorted(_returned_data, key=lambda k: k[1], reverse=False)
+    return [(json.loads(asset[0]), asset[1]) for asset in sorted_assets]
 
 
 @register_query(TarantoolDBConnection)

--- a/planetmint/transactions/common/transaction.py
+++ b/planetmint/transactions/common/transaction.py
@@ -693,7 +693,8 @@ class Transaction(object):
         assets = list(planet.get_assets(tx_ids))
         for asset in assets:
             if asset is not None:
-                tx = tx_map[asset[1]]
+                if 'id' in asset:
+                    tx = tx_map[asset['id']]
                 tx['asset'] = asset
 
         tx_ids = list(tx_map.keys())

--- a/planetmint/transactions/common/transaction.py
+++ b/planetmint/transactions/common/transaction.py
@@ -695,7 +695,7 @@ class Transaction(object):
             if asset is not None:
                 if 'id' in asset:
                     tx = tx_map[asset['id']]
-                tx['asset'] = asset
+                tx['asset'] = asset[0]
 
         tx_ids = list(tx_map.keys())
         metadata_list = list(planet.get_metadata(tx_ids))

--- a/tests/backend/tarantool/test_queries.py
+++ b/tests/backend/tarantool/test_queries.py
@@ -58,7 +58,7 @@ def test_write_assets(db_conn):
     documents = query.get_assets(assets_ids=[asset["id"] for asset in assets], connection=db_conn)
 
     assert len(documents) == 3
-    assert list(documents)[0] == assets[:-1][0]
+    assert list(documents)[0][0] == assets[:-1][0]
 
 
 def test_get_assets(db_conn):


### PR DESCRIPTION
Make sure the title of this pull request has the form:

**Problem: Failure of unit tests due to `KeyError: id` while testing with Tarantool.**

## Solution

The issue generated because of the difference of fetching data between MongoDB and Tarantool. The default behaviour in Tarantool does not return None if some data is not found while in MongoDB, None was returned in such cases.

Hence, I added the logic of returning None if the value is not found. 

## Issues Resolved

Resolves #142 
