### PR TITLE
Removed 'sorted' from query.get_assets

### DIFF
--- a/planetmint/backend/tarantool/query.py
+++ b/planetmint/backend/tarantool/query.py
@@ -171,7 +171,7 @@ def get_assets(connection, assets_ids: list) -> list:
         asset = get_asset(connection, _id)
         _returned_data.append(asset)
 
-    return sorted(_returned_data, key=lambda k: k["id"], reverse=False)
+    return _returned_data
 
 
 @register_query(TarantoolDBConnection)

--- a/tests/backend/tarantool/test_queries.py
+++ b/tests/backend/tarantool/test_queries.py
@@ -56,7 +56,7 @@ def test_write_assets(db_conn):
 
     # check that 3 assets were written to the database
     documents = query.get_assets(assets_ids=[asset["id"] for asset in assets], connection=db_conn)
-
+    documents = sorted(documents, key=lambda k: k["id"], reverse=False)  # sorting to fit test-case
     assert len(documents) == 3
     assert list(documents)[0] == assets[:-1][0]
 


### PR DESCRIPTION
## Problem
Data is coming in random order from tarantool, so was added sorting for assets by id.
But some assets don't have id field, so we encountered some problems

## Solution
sorted function was removed from query.get_assets, and it was added directly to test-case that requires that.