### PR TITLE
Planetmint tarantool

### DIFF
--- a/planetmint/backend/tarantool/query.py
+++ b/planetmint/backend/tarantool/query.py
@@ -168,10 +168,13 @@ def get_asset(connection, asset_id: str):
 def get_assets(connection, assets_ids: list) -> list:
     _returned_data = []
     for _id in list(set(assets_ids)):
-        asset = get_asset(connection, _id)
-        _returned_data.append(asset)
+        res = connection.run(
+            connection.space("assets").select(_id, index="txid_search")
+        )
+        _returned_data.append(res[0])
 
-    return sorted(_returned_data, key=lambda k: k["id"], reverse=False)
+    sorted_assets = sorted(_returned_data, key=lambda k: k[1], reverse=False)
+    return [(json.loads(asset[0]), asset[1]) for asset in sorted_assets]
 
 
 @register_query(TarantoolDBConnection)

--- a/planetmint/transactions/common/transaction.py
+++ b/planetmint/transactions/common/transaction.py
@@ -693,6 +693,7 @@ class Transaction(object):
         assets = list(planet.get_assets(tx_ids))
         for asset in assets:
             if asset is not None:
+                # This is tarantool specific behaviour needs to be addressed
                 tx = tx_map[asset[1]]
                 tx['asset'] = asset[0]
 

--- a/planetmint/transactions/common/transaction.py
+++ b/planetmint/transactions/common/transaction.py
@@ -694,7 +694,7 @@ class Transaction(object):
         for asset in assets:
             if asset is not None:
                 tx = tx_map[asset[1]]
-                tx['asset'] = asset
+                tx['asset'] = asset[0]
 
         tx_ids = list(tx_map.keys())
         metadata_list = list(planet.get_metadata(tx_ids))

--- a/tests/backend/tarantool/test_queries.py
+++ b/tests/backend/tarantool/test_queries.py
@@ -58,7 +58,7 @@ def test_write_assets(db_conn):
     documents = query.get_assets(assets_ids=[asset["id"] for asset in assets], connection=db_conn)
 
     assert len(documents) == 3
-    assert list(documents)[0] == assets[:-1][0]
+    assert list(documents)[0][0] == assets[:-1][0]
 
 
 def test_get_assets(db_conn):


### PR DESCRIPTION
## Description
This PR resolves the issue with `get_assets`. It now returns a list of tuples that contain `data` on the first index and `id` on the second. This is because the `Transaction.form_db()` function expects the id to be present to append the correct asset to it's transaction.

## Ongoing issues
 - Some tarantool specific changes have been made to `Transaciton` 
 - The `test_naughty_strings.py` acceptance test fails on some occasions
 - The integration tests fail at the moment

Issues will be created for the ongoing issues