### PR TITLE
Transaction hierarchy

### DIFF
--- a/planetmint/__init__.py
+++ b/planetmint/__init__.py
@@ -4,7 +4,6 @@
 # Code is Apache-2.0 and docs are CC-BY-4.0
 
 from planetmint.transactions.common.transaction import Transaction  # noqa
-from planetmint import models  # noqa
 from planetmint.upsert_validator import ValidatorElection  # noqa
 from planetmint.transactions.types.elections.vote import Vote  # noqa
 from planetmint.transactions.types.elections.chain_migration_election import ChainMigrationElection
@@ -12,8 +11,8 @@ from planetmint.lib import Planetmint
 from planetmint.core import App
 
 
-Transaction.register_type(Transaction.CREATE, models.Transaction)
-Transaction.register_type(Transaction.TRANSFER, models.Transaction)
+Transaction.register_type(Transaction.CREATE, Transaction)
+Transaction.register_type(Transaction.TRANSFER, Transaction)
 Transaction.register_type(ValidatorElection.OPERATION, ValidatorElection)
 Transaction.register_type(ChainMigrationElection.OPERATION, ChainMigrationElection)
 Transaction.register_type(Vote.OPERATION, Vote)

--- a/planetmint/lib.py
+++ b/planetmint/lib.py
@@ -24,7 +24,7 @@ import requests
 import planetmint
 from planetmint.config import Config
 from planetmint import backend, config_utils, fastquery
-from planetmint.models import Transaction
+from planetmint.transactions.common.transaction import Transaction
 from planetmint.transactions.common.exceptions import SchemaValidationError, ValidationError, DoubleSpend
 from planetmint.transactions.common.transaction_mode_types import (
     BROADCAST_TX_COMMIT,
@@ -248,7 +248,7 @@ class Planetmint(object):
 
                 transaction.update({"metadata": metadata})
 
-            transaction = Transaction.from_dict(transaction)
+            transaction = Transaction.from_dict(transaction, False)
 
         return transaction
 
@@ -301,7 +301,7 @@ class Planetmint(object):
             raise DoubleSpend('tx "{}" spends inputs twice'.format(txid))
         elif transactions:
             transaction = backend.query.get_transactions(self.connection, [transactions[0]["id"]])
-            transaction = Transaction.from_dict(transaction[0])
+            transaction = Transaction.from_dict(transaction[0], False)
         elif current_spent_transactions:
             transaction = current_spent_transactions[0]
 
@@ -368,7 +368,7 @@ class Planetmint(object):
         # throught the code base.
         if isinstance(transaction, dict):
             try:
-                transaction = Transaction.from_dict(tx)
+                transaction = Transaction.from_dict(tx, False)
             except SchemaValidationError as e:
                 logger.warning("Invalid transaction schema: %s", e.__cause__.message)
                 return False

--- a/planetmint/transactions/common/transaction.py
+++ b/planetmint/transactions/common/transaction.py
@@ -185,7 +185,6 @@ class Transaction(object):
 
         return self
 
-
     @property
     def unspent_outputs(self):
         """UnspentOutput: The outputs of this transaction, in a data

--- a/planetmint/transactions/common/transaction.py
+++ b/planetmint/transactions/common/transaction.py
@@ -124,7 +124,6 @@ class Transaction(object):
             allowed_ops = ", ".join(self.__class__.ALLOWED_OPERATIONS)
             raise ValueError("`operation` must be one of {}".format(allowed_ops))
 
-
         # Asset payloads for 'CREATE' operations must be None or
         # dicts holding a `data` property. Asset payloads for 'TRANSFER'
         # operations must be dicts holding an `id` property.
@@ -724,7 +723,6 @@ class Transaction(object):
         Returns:
             :class:`~planetmint.transactions.common.transaction.Transaction`
         """
-
         operation = tx.get("operation", Transaction.CREATE) if isinstance(tx, dict) else Transaction.CREATE
         cls = Transaction.resolve_class(operation)
 
@@ -829,7 +827,6 @@ class Transaction(object):
     def register_type(tx_type, tx_class):
         Transaction.type_registry[tx_type] = tx_class
 
-    # TODO: Figure out why this is always uses the create_txn_class 
     def resolve_class(operation):
         """For the given `tx` based on the `operation` key return its implementation class"""
 

--- a/planetmint/transactions/common/transaction.py
+++ b/planetmint/transactions/common/transaction.py
@@ -124,7 +124,6 @@ class Transaction(object):
             allowed_ops = ", ".join(self.__class__.ALLOWED_OPERATIONS)
             raise ValueError("`operation` must be one of {}".format(allowed_ops))
 
-        # TODO: Move operation specific validation to sub classes
 
         # Asset payloads for 'CREATE' operations must be None or
         # dicts holding a `data` property. Asset payloads for 'TRANSFER'
@@ -174,7 +173,6 @@ class Transaction(object):
         """
         input_conditions = []
 
-        # TODO: Move to Create(Transaction)
         if self.operation == Transaction.CREATE:
             duplicates = any(txn for txn in current_transactions if txn.id == self.id)
             if planet.is_committed(self.id) or duplicates:
@@ -183,13 +181,11 @@ class Transaction(object):
             if not self.inputs_valid(input_conditions):
                 raise InvalidSignature("Transaction signature is invalid.")
 
-        # TODO: Move to Transfer(Transaction)
         elif self.operation == Transaction.TRANSFER:
             self.validate_transfer_inputs(planet, current_transactions)
 
         return self
 
-    # TODO: Make this abstract, implement unspent_outputs in sub classes
 
     @property
     def unspent_outputs(self):
@@ -567,8 +563,6 @@ class Transaction(object):
             print(f"Exception ASN1EncodeError : {e}")
             return False
 
-        # TODO: find out how to resolve this
-
         if operation == self.CREATE:
             # NOTE: In the case of a `CREATE` transaction, the
             #       output is always valid.
@@ -687,8 +681,6 @@ class Transaction(object):
         if not isinstance(transactions, list):
             transactions = [transactions]
 
-        # TODO: How to decouple this?
-
         # create a set of the transactions' asset ids
         asset_ids = {tx.id if tx.operation == tx.CREATE else tx.asset["id"] for tx in transactions}
 
@@ -732,8 +724,6 @@ class Transaction(object):
         Returns:
             :class:`~planetmint.transactions.common.transaction.Transaction`
         """
-        # NOTE: this is the place where the Transaction.resolve_class function is called. 
-        # TODO: Resolve CREATE somewhere else. Figure out where this is called with tx as something else as dict
 
         operation = tx.get("operation", Transaction.CREATE) if isinstance(tx, dict) else Transaction.CREATE
         cls = Transaction.resolve_class(operation)
@@ -853,8 +843,6 @@ class Transaction(object):
         validate_txn_obj(cls.METADATA, tx, cls.METADATA, validate_key)
         validate_language_key(tx[cls.ASSET], cls.DATA)
         validate_language_key(tx, cls.METADATA)
-
-    # TODO: this should be in the Transfer(Transaction) class
 
     def validate_transfer_inputs(self, planet, current_transactions=[]):
         # store the inputs so that we can check if the asset ids match

--- a/planetmint/transactions/types/assets/create.py
+++ b/planetmint/transactions/types/assets/create.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
 # Code is Apache-2.0 and docs are CC-BY-4.0
 
-from planetmint.models import Transaction
+from planetmint.transactions.common.transaction import Transaction
 from planetmint.transactions.common.input import Input
 from planetmint.transactions.common.output import Output
 

--- a/planetmint/transactions/types/assets/transfer.py
+++ b/planetmint/transactions/types/assets/transfer.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: (Apache-2.0 AND CC-BY-4.0)
 # Code is Apache-2.0 and docs are CC-BY-4.0
 
-from planetmint.models import Transaction
+from planetmint.transactions.common.transaction import Transaction
 from planetmint.transactions.common.output import Output
 from copy import deepcopy
 

--- a/planetmint/web/views/transactions.py
+++ b/planetmint/web/views/transactions.py
@@ -19,7 +19,7 @@ from planetmint.transactions.common.exceptions import (
 )
 from planetmint.web.views.base import make_error
 from planetmint.web.views import parameters
-from planetmint.models import Transaction
+from planetmint.transactions.common.transaction import Transaction
 
 
 logger = logging.getLogger(__name__)
@@ -76,7 +76,7 @@ class TransactionListApi(Resource):
         tx = request.get_json(force=True)
 
         try:
-            tx_obj = Transaction.from_dict(tx)
+            tx_obj = Transaction.from_dict(tx, False)
         except SchemaValidationError as e:
             return make_error(
                 400,

--- a/tests/assets/test_digital_assets.py
+++ b/tests/assets/test_digital_assets.py
@@ -33,14 +33,14 @@ def test_validate_transfer_asset_id_mismatch(b, signed_create_tx, user_pk, user_
 
 
 def test_get_asset_id_create_transaction(alice, user_pk):
-    from planetmint.models import Transaction
+    from planetmint.transactions.common.transaction import Transaction
 
     tx_create = Create.generate([alice.public_key], [([user_pk], 1)])
     assert Transaction.get_asset_id(tx_create) == tx_create.id
 
 
 def test_get_asset_id_transfer_transaction(b, signed_create_tx, user_pk):
-    from planetmint.models import Transaction
+    from planetmint.transactions.common.transaction import Transaction
 
     tx_transfer = Transfer.generate(signed_create_tx.to_inputs(), [([user_pk], 1)], signed_create_tx.id)
     asset_id = Transaction.get_asset_id(tx_transfer)
@@ -48,7 +48,7 @@ def test_get_asset_id_transfer_transaction(b, signed_create_tx, user_pk):
 
 
 def test_asset_id_mismatch(alice, user_pk):
-    from planetmint.models import Transaction
+    from planetmint.transactions.common.transaction import Transaction
     from planetmint.transactions.common.exceptions import AssetIdMismatch
 
     tx1 = Create.generate([alice.public_key], [([user_pk], 1)], metadata={"msg": random.random()})

--- a/tests/assets/test_zenroom_signing.py
+++ b/tests/assets/test_zenroom_signing.py
@@ -149,7 +149,7 @@ def test_zenroom_signing():
     shared_creation_txid = sha3_256(json_str_tx.encode()).hexdigest()
     tx["id"] = shared_creation_txid
 
-    from planetmint.models import Transaction
+    from planetmint.transactions.common.transaction import Transaction
     from planetmint.lib import Planetmint
     from planetmint.transactions.common.exceptions import (
         SchemaValidationError,
@@ -158,7 +158,7 @@ def test_zenroom_signing():
 
     try:
         print(f"TX\n{tx}")
-        tx_obj = Transaction.from_dict(tx)
+        tx_obj = Transaction.from_dict(tx, False)
     except SchemaValidationError as e:
         print(e)
         assert ()

--- a/tests/backend/tarantool/test_queries.py
+++ b/tests/backend/tarantool/test_queries.py
@@ -7,6 +7,7 @@ from copy import deepcopy
 
 import pytest
 import json
+from planetmint.transactions.common.transaction import Transaction
 from planetmint.transactions.types.assets.create import Create
 from planetmint.transactions.types.assets.transfer import Transfer
 
@@ -15,7 +16,6 @@ pytestmark = pytest.mark.bdb
 
 def test_get_txids_filtered(signed_create_tx, signed_transfer_tx, db_conn):
     from planetmint.backend.tarantool import query
-    from planetmint.models import Transaction
 
     # create and insert two blocks, one for the create and one for the
     # transfer transaction

--- a/tests/common/test_memoize.py
+++ b/tests/common/test_memoize.py
@@ -6,7 +6,7 @@
 import pytest
 from copy import deepcopy
 
-from planetmint.models import Transaction
+from planetmint.transactions.common.transaction import Transaction
 from planetmint.transactions.types.assets.create import Create
 from planetmint.transactions.common.crypto import generate_key_pair
 from planetmint.transactions.common.memoize import to_dict, from_dict

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -141,7 +141,7 @@ def _setup_database(_configure_planetmint):  # TODO Here is located setup databa
 @pytest.fixture
 def _bdb(_setup_database, _configure_planetmint):
     from planetmint.transactions.common.memoize import to_dict, from_dict
-    from planetmint.models import Transaction
+    from planetmint.transactions.common.transaction import Transaction
     from .utils import flush_db
     from planetmint.config import Config
 

--- a/tests/validation/test_transaction_structure.py
+++ b/tests/validation/test_transaction_structure.py
@@ -18,7 +18,7 @@ except ImportError:
 from unittest.mock import MagicMock
 
 from planetmint.transactions.common.exceptions import AmountError, SchemaValidationError, ThresholdTooDeep
-from planetmint.models import Transaction
+from planetmint.transactions.common.transaction import Transaction
 from planetmint.transactions.common.utils import _fulfillment_to_details, _fulfillment_from_details
 
 ################################################################################
@@ -28,7 +28,7 @@ from planetmint.transactions.common.utils import _fulfillment_to_details, _fulfi
 def validate(tx):
     if isinstance(tx, Transaction):
         tx = tx.to_dict()
-    Transaction.from_dict(tx)
+    Transaction.from_dict(tx, False)
 
 
 def validate_raises(tx, exc=SchemaValidationError):
@@ -38,7 +38,7 @@ def validate_raises(tx, exc=SchemaValidationError):
 
 # We should test that validation works when we expect it to
 def test_validation_passes(signed_create_tx):
-    Transaction.from_dict(signed_create_tx.to_dict())
+    Transaction.from_dict(signed_create_tx.to_dict(), False)
 
 
 ################################################################################
@@ -53,7 +53,6 @@ def test_tx_serialization_hash_function(signed_create_tx):
 
 
 def test_tx_serialization_with_incorrect_hash(signed_create_tx):
-    from planetmint.transactions.common.transaction import Transaction
     from planetmint.transactions.common.exceptions import InvalidHash
 
     tx = signed_create_tx.to_dict()
@@ -68,7 +67,7 @@ def test_tx_serialization_with_no_hash(signed_create_tx):
     tx = signed_create_tx.to_dict()
     del tx["id"]
     with pytest.raises(InvalidHash):
-        Transaction.from_dict(tx)
+        Transaction.from_dict(tx, False)
 
 
 ################################################################################

--- a/tests/web/test_transactions.py
+++ b/tests/web/test_transactions.py
@@ -311,7 +311,10 @@ def test_post_invalid_transaction(
 
     TransactionMock = Mock(validate=mock_validation)
 
-    monkeypatch.setattr("planetmint.transactions.common.transaction.Transaction.from_dict", lambda tx, skip_schema_validation: TransactionMock)
+    monkeypatch.setattr(
+        "planetmint.transactions.common.transaction.Transaction.from_dict",
+        lambda tx, skip_schema_validation: TransactionMock,
+    )
     res = client.post(TX_ENDPOINT, data=json.dumps({}))
     expected_status_code = 400
     expected_error_message = "Invalid transaction ({}): {}".format(exc, msg)

--- a/tests/web/test_transactions.py
+++ b/tests/web/test_transactions.py
@@ -306,12 +306,12 @@ def test_post_invalid_transaction(
 
     exc_cls = getattr(exceptions, exc)
 
-    def mock_validation(self_, tx):
+    def mock_validation(self_, tx, skip_schema_validation):
         raise exc_cls(msg)
 
     TransactionMock = Mock(validate=mock_validation)
 
-    monkeypatch.setattr("planetmint.transactions.common.transaction.Transaction.from_dict", lambda tx: TransactionMock)
+    monkeypatch.setattr("planetmint.transactions.common.transaction.Transaction.from_dict", lambda tx, skip_schema_validation: TransactionMock)
     res = client.post(TX_ENDPOINT, data=json.dumps({}))
     expected_status_code = 400
     expected_error_message = "Invalid transaction ({}): {}".format(exc, msg)

--- a/tests/web/test_transactions.py
+++ b/tests/web/test_transactions.py
@@ -311,7 +311,7 @@ def test_post_invalid_transaction(
 
     TransactionMock = Mock(validate=mock_validation)
 
-    monkeypatch.setattr("planetmint.models.Transaction.from_dict", lambda tx: TransactionMock)
+    monkeypatch.setattr("planetmint.transactions.common.transaction.Transaction.from_dict", lambda tx: TransactionMock)
     res = client.post(TX_ENDPOINT, data=json.dumps({}))
     expected_status_code = 400
     expected_error_message = "Invalid transaction ({}): {}".format(exc, msg)

--- a/tests/web/test_transactions.py
+++ b/tests/web/test_transactions.py
@@ -306,7 +306,7 @@ def test_post_invalid_transaction(
 
     exc_cls = getattr(exceptions, exc)
 
-    def mock_validation(self_, tx, skip_schema_validation):
+    def mock_validation(self_, tx, skip_schema_validation=True):
         raise exc_cls(msg)
 
     TransactionMock = Mock(validate=mock_validation)


### PR DESCRIPTION
## Description
I removed the `Transaction` class from `models.py` and replaced imports and calls with `Transaction` from `transaction.py`. `Create` and `Transfer` now directly inherit `transaction.py::Transaction`