### PR TITLE
fixed 'make run' : using tarantool instead of mongodb

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,7 @@ run: check-deps ## Run Planetmint from source (stop it with ctrl+c)
 	# although planetmint has tendermint and mongodb in depends_on,
 	# launch them first otherwise tendermint will get stuck upon sending yet another log
 	# due to some docker-compose issue; does not happen when containers are run as daemons
-	@$(DC) up --no-deps mongodb tendermint planetmint
+	@$(DC) up --no-deps tarantool tendermint planetmint
 
 start: check-deps ## Run Planetmint from source and daemonize it (stop with `make stop`)
 	@$(DC) up -d planetmint
@@ -144,3 +144,4 @@ ifndef IS_BLACK_INSTALLED
 	@$(ECHO) "You need to activate your virtual environment and install the test dependencies"
 	black # black is not installed, so we call it to generate an error and exit
 endif
+

--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,7 @@ help: ## Show this help
 	@$(HELP) < $(MAKEFILE_LIST)
 
 run: check-deps ## Run Planetmint from source (stop it with ctrl+c)
-	# although planetmint has tendermint and mongodb in depends_on,
+	# although planetmint has tendermint and tarantool in depends_on,
 	# launch them first otherwise tendermint will get stuck upon sending yet another log
 	# due to some docker-compose issue; does not happen when containers are run as daemons
 	@$(DC) up --no-deps tarantool tendermint planetmint


### PR DESCRIPTION
Issue: tarantool wasn't started by the make run command.

solution: replace mongodb container by tarantool container in the makefile