### PR TITLE
increased protobuf version number to fx the potential exploit

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -128,7 +128,7 @@ install_requires = [
     "setproctitle==1.2.2",
     "werkzeug==2.0.3",
     "nest-asyncio==1.5.5",
-    "protobuf==3.20.1",
+    "protobuf>=3.20.2",
     "planetmint-ipld>=0.0.3",
     "pyasn1",
     "zenroom==2.1.0.dev1655293214",


### PR DESCRIPTION
Summary
A message parsing and memory management vulnerability in ProtocolBuffer’s C++ and Python implementations can trigger an out of memory (OOM) failure when processing a specially crafted message, which could lead to a denial of service (DoS) on services using the libraries.

Reporter: [ClusterFuzz](https://google.github.io/clusterfuzz/)

Affected versions: All versions of C++ Protobufs (including Python) prior to the versions listed below.

Severity & Impact
Medium 5.7 - [CVSS:3.1/AV:A/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:H](https://www.first.org/cvss/calculator/3.1#CVSS:3.1/AV:A/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:H)

A small (~500 KB) malicious payload can be constructed which causes the running service to allocate more than 3GB of RAM.

Proof of Concept
For reproduction details, please refer to the unit test that identifies the specific inputs that exercise this parsing weakness.

Mitigation / Patching
Please update to the latest available versions of the following packages:

protobuf-cpp (3.18.3, 3.19.5, 3.20.2, 3.21.6)
protobuf-python (3.18.3, 3.19.5, 3.20.2, 4.21.6)