### PR TITLE
fixed bug : roll back caused from_dict call on a None object

### DIFF
--- a/planetmint/lib.py
+++ b/planetmint/lib.py
@@ -917,9 +917,12 @@ class Planetmint(object):
         # elections concluded at this height
         self.delete_elections(new_height)
 
-        txns = [self.get_transaction(tx_id) for tx_id in txn_ids]
-
-        txns = [Transaction.from_dict(tx.to_dict()) for tx in txns]
+        txids = [self.get_transaction(tx_id) for tx_id in txn_ids]
+        txns = []
+        if len( txids ) > 0:
+            for tx in txids:
+                if tx:
+                    txns.append(Transaction.from_dict(tx.to_dict()) )
 
         elections = self._get_votes(txns)
         for election_id in elections:


### PR DESCRIPTION
During rollbacks a call on None-objects caused crashes.
Appeared on the validator nodes.

## Checklist

- [ ] version number increased
- [ ] CHANGELOG.md updated
- [ ] unit test added
- [ ] documentation updated or added